### PR TITLE
Added initial logic for the start button functionality

### DIFF
--- a/src/Pendulum/case1/sketch.js
+++ b/src/Pendulum/case1/sketch.js
@@ -31,8 +31,12 @@ createWorld(); // add bodies to canvas
 State.setSimulationTime(Date.now()); // sets the timer for the simulation
 
 Render.run(render); // allow for the rendering of frames of the world
+var startBtn = document.getElementById("start-button");
+startBtn.onclick = function() {
+  renderLoop(); // renders frames to the canvas
+  State.setRunningTime(0.0);
+}
 
-renderLoop(); // renders frames to the canvas
 
 /*
   * Renders frames to send to the canvas


### PR DESCRIPTION
The webpage starts off with the webpage not moving and the start button triggers it

Note: There's a bug in that when you press the button multiple times it gets faster.
The reset button does not go back to the start button position, but it plays automatically.