### PR TITLE
Changes simulation time displayed to rely on engine's timing

### DIFF
--- a/src/Pendulum/State.js
+++ b/src/Pendulum/State.js
@@ -4,8 +4,6 @@ let State = (function() {
   let Render = Matter.Render;
   let _simulationRunning = false;
   let _isPausedFlag = true;
-  let _simulationTime = 0;
-  let _runningTime = 0;
 
   return {
     /**
@@ -54,73 +52,25 @@ let State = (function() {
         Render.stop(render);
       }
       else {
-        this.setSimulationTime(Date.now());
         Render.run(render);
       }
-    },
-
-    /**
-      * Increments the amount of time the simulation has been running
-    */
-
-    sumRunningTime: function() {
-      _runningTime += (Date.now() - this.getSimulationTime()) / 1000;
-      this.setSimulationTime(Date.now());
-    },
-
-    /**
-      * Updates the value of _runningTime
-      * @param {float} time - the time the simulation has been running for
-    */
-
-    setRunningTime: function(time) {
-      _runningTime = time;
-    },
-
-    /**
-      * Returns the current time in seconds the simulation has been running
-      * @returns {State} _runningTime
-    */
-
-    getRunningTime: function() {
-      return Math.floor(_runningTime);
-    },
-
-    /**
-      * Updates the value of _simulationTime
-      * @param {Date} date - the current date of the simulation
-    */
-
-    setSimulationTime: function(date) {
-      _simulationTime = date;
-    },
-
-    /**
-      * Returns the previous simulation time
-      * @returns {State} _simulationTime
-    */
-
-    getSimulationTime: function() {
-      return _simulationTime;
     },
 
     /**
       * Displays to the user the current running time of the simulation
     */
 
-    displayRunningTime: function() {
-      this.sumRunningTime();
-
-      let currentTime = this.getRunningTime();
+    displayRunningTime: function(engine) {
+      let currentTime = (engine.timing.timestamp / 1000).toFixed(3);
 
       if (currentTime > 60) { // more than a minute has gone by
         let quotient = Math.floor(currentTime / 60); // minutes
-        let remainder = currentTime % 60; // seconds
+        let remainder = (currentTime % 60).toFixed(3); // seconds
 
-        document.getElementById('running-time').textContent = 'Time: ' + quotient + ' Minutes ' + remainder + ' Seconds';
+        document.getElementById('running-time').textContent = 'Time: ' + quotient + 'm ' + remainder + 's';
       }
       else {
-        document.getElementById('running-time').textContent = 'Time: ' + currentTime + ' Seconds';
+        document.getElementById('running-time').textContent = 'Time: ' + currentTime + 's';
       }
     },
   };

--- a/src/Pendulum/case1/sketch.js
+++ b/src/Pendulum/case1/sketch.js
@@ -34,8 +34,6 @@ let render = Render.create({
 
 createWorld(); // add bodies to canvas
 
-State.setSimulationTime(Date.now()); // sets the timer for the simulation
-
 Render.run(render); // allow for the rendering of frames of the world
 
 renderLoop(); // renders frames to the canvas
@@ -90,7 +88,7 @@ function renderLoop() {
 
     pendulum.pendulumAngle = pendulum.calculateAngle(pendulum.pendulumString.bodies[0].position, pendulum.pendulumBody.position);
     pendulum.displayPendulumAngle();
-    State.displayRunningTime();
+    State.displayRunningTime(engine);
 
     addData(myChart, {x: engine.timing.timestamp, y: pendulum.pendulumAngle});
   }
@@ -159,23 +157,13 @@ document.getElementById('start-button').onclick = function() {
 document.getElementById('reset-button').onclick = function() {
   World.clear(engine.world);
   createWorld();
-  State.setRunningTime(0.0);
+  engine.timing.timestamp = 0;
 
   if (State.getIsPausedFlag() === true) {
     State.setIsPausedFlag(!State.getIsPausedFlag());
     Render.run(render);
   }
 };
-
-/**
-  * Listens for whether the current browser tab is active or not
-*/
-
-document.addEventListener('visibilitychange', function() {
-  if (!document.hidden) {
-    State.setSimulationTime(Date.now());
-  }
-});
 
 /*
 * Adds data points to the chart.


### PR DESCRIPTION
This changes the displayed running time to the user to rely on the time the engine has. This number will be accurate to the current time the simulation is at. This will mean that if the simulation is lagging behind it will not be an accurate representation of real time, but of the simulation's current time.