### PR TITLE
Implements generic build, clean, and minify for building project

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,11 +1,48 @@
 let gulp = require('gulp');
+let terser = require('gulp-terser');
+let clean = require('gulp-clean');
+let fs = require('fs');
 let browserify = require('browserify');
 let source = require('vinyl-source-stream');
 
-/*
-  * Builds the Pendulum case 1 source files
+/**
+  * Minifies all js files in the build folder
 */
 
-gulp.task('build-case1', async () => {
-  browserify('./src/Pendulum/case1/Sketch.js').bundle().pipe(source('bundle.js')).pipe(gulp.dest('./src/Pendulum/case1'));
+gulp.task('minify', () => {
+  return gulp.src('./build/*.js').pipe(terser()).pipe(gulp.dest('./build'), {mode: 0777});
+});
+
+
+/**
+  * Builds a pendulum case to the build folder
+  * Takes a command line argument --case [case] where case is a folder name
+*/
+
+gulp.task('build', async () => {
+  if (process.argv.indexOf('--case') !== -1) {
+    let folder = process.argv[process.argv.indexOf('--case') + 1];
+
+    browserify(`./src/Pendulum/${folder}/Sketch.js`).bundle().pipe(source('bundle.js')).pipe(gulp.dest('./build'), {mode: 0777});
+    gulp.src(`./src/Pendulum/${folder}/**/*.css`).pipe(gulp.dest('./build'), {mode: 0777});
+    gulp.src(`./src/Pendulum/${folder}/**/*.html`).pipe(gulp.dest('./build'), {mode: 0777});
+  }
+  else {
+    console.log('Error: The folder to build was not specified. Enter the command gulp build-case --case [Your Case].');
+  }
+});
+
+/**
+  * Cleans the build directory
+*/
+
+gulp.task('clean', async () => {
+  fs.access('./build', (error) => {
+    if (error) {
+      console.log('Error: ./build does not exist.');
+    }
+    else {
+      gulp.src('./build', {read: false}).pipe(clean(), {mode: 0777});
+    }
+  });
 });

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "devDependencies": {
     "browserify": "^16.2.3",
-    "gulp": "^4.0.0"
+    "gulp": "^4.0.0",
+    "gulp-clean": "^0.4.0",
+    "gulp-terser": "^1.1.7"
   }
 }


### PR DESCRIPTION
I have made a generic build so that each case can be compiled into a build folder separately. There are two new tasks as well.

- minify

- clean

The minify command can will minify any JavaScript files in the build directory. This will be useful when uploading it to the server, not really for development so it is omitted in the build. The clean command simply deletes the build folder. 