### PR TITLE
Fixes bug where user could unpause after simulation finished.

### DIFF
--- a/src/Pendulum/case1/sketch.js
+++ b/src/Pendulum/case1/sketch.js
@@ -128,19 +128,21 @@ function stopPlotInterval() {
 var pauseBtn = document.getElementById('pause-button');
 
 pauseBtn.onclick = function() {
-  if (pauseBtn.value == "pause") {
-    pauseBtn.innerText = "cont.";
-    pauseBtn.value = "continue";
-    stopPlotInterval();
-  }
-  else {
-    pauseBtn.value = "pause";
-    pauseBtn.innerText = "Pause";
-    runPlotInterval();
-  }
+  if (State.getSimulationRunning() === true) { // only allow pause and continue when the simulation is running
+    if (pauseBtn.value == "pause") {
+      pauseBtn.innerText = "cont.";
+      pauseBtn.value = "continue";
+      stopPlotInterval();
+    }
+    else {
+      pauseBtn.value = "pause";
+      pauseBtn.innerText = "Pause";
+      runPlotInterval();
+    }
 
-  State.setIsPausedFlag(!State.getIsPausedFlag());
-  State.onPause(render);
+    State.setIsPausedFlag(!State.getIsPausedFlag());
+    State.onPause(render);
+  }
 };
 
 /*
@@ -195,5 +197,6 @@ Events.on(engine, 'beforeUpdate', function(event) {
     State.setIsPausedFlag(true);
     State.onPause(render);
     stopPlotInterval();
+    State.setSimulationRunning(false);
   }
 });

--- a/src/Pendulum/case2/sketch.js
+++ b/src/Pendulum/case2/sketch.js
@@ -154,19 +154,21 @@ function stopPlotInterval() {
 var pauseBtn = document.getElementById('pause-button');
 
 pauseBtn.onclick = function() {
-  if (pauseBtn.value == "pause") {
-    pauseBtn.innerText = "cont.";
-    pauseBtn.value = "continue";
-    stopPlotInterval();
-  }
-  else {
-    pauseBtn.value = "pause";
-    pauseBtn.innerText = "Pause";
-    runPlotInterval();
-  }
+  if (State.getSimulationRunning() === true) { // only allow pause and continue when the simulation is running
+    if (pauseBtn.value == "pause") {
+      pauseBtn.innerText = "cont.";
+      pauseBtn.value = "continue";
+      stopPlotInterval();
+    }
+    else {
+      pauseBtn.value = "pause";
+      pauseBtn.innerText = "Pause";
+      runPlotInterval();
+    }
 
-  State.setIsPausedFlag(!State.getIsPausedFlag());
-  State.onPause(render);
+    State.setIsPausedFlag(!State.getIsPausedFlag());
+    State.onPause(render);
+  }
 };
 
 /*
@@ -225,5 +227,6 @@ Events.on(engine, 'beforeUpdate', function(event) {
     State.setIsPausedFlag(true);
     State.onPause(render);
     stopPlotInterval();
+    State.setSimulationRunning(false);
   }
 });

--- a/src/Pendulum/case3/sketch.js
+++ b/src/Pendulum/case3/sketch.js
@@ -154,19 +154,21 @@ function stopPlotInterval() {
 var pauseBtn = document.getElementById('pause-button');
 
 pauseBtn.onclick = function() {
-  if (pauseBtn.value == "pause") {
-    pauseBtn.innerText = "cont.";
-    pauseBtn.value = "continue";
-    stopPlotInterval();
-  }
-  else {
-    pauseBtn.value = "pause";
-    pauseBtn.innerText = "Pause";
-    runPlotInterval();
-  }
+  if (State.getSimulationRunning() === true) { // only allow pause and continue when the simulation is running
+    if (pauseBtn.value == "pause") {
+      pauseBtn.innerText = "cont.";
+      pauseBtn.value = "continue";
+      stopPlotInterval();
+    }
+    else {
+      pauseBtn.value = "pause";
+      pauseBtn.innerText = "Pause";
+      runPlotInterval();
+    }
 
-  State.setIsPausedFlag(!State.getIsPausedFlag());
-  State.onPause(render);
+    State.setIsPausedFlag(!State.getIsPausedFlag());
+    State.onPause(render);
+  }
 };
 
 /*
@@ -225,5 +227,6 @@ Events.on(engine, 'beforeUpdate', function(event) {
     State.setIsPausedFlag(true);
     State.onPause(render);
     stopPlotInterval();
+    State.setSimulationRunning(false);
   }
 });

--- a/src/Pendulum/case4/sketch.js
+++ b/src/Pendulum/case4/sketch.js
@@ -154,19 +154,21 @@ function stopPlotInterval() {
 var pauseBtn = document.getElementById('pause-button');
 
 pauseBtn.onclick = function() {
-  if (pauseBtn.value == "pause") {
-    pauseBtn.innerText = "cont.";
-    pauseBtn.value = "continue";
-    stopPlotInterval();
-  }
-  else {
-    pauseBtn.value = "pause";
-    pauseBtn.innerText = "Pause";
-    runPlotInterval();
-  }
+  if (State.getSimulationRunning() === true) { // only allow pause and continue when the simulation is running
+    if (pauseBtn.value == "pause") {
+      pauseBtn.innerText = "cont.";
+      pauseBtn.value = "continue";
+      stopPlotInterval();
+    }
+    else {
+      pauseBtn.value = "pause";
+      pauseBtn.innerText = "Pause";
+      runPlotInterval();
+    }
 
-  State.setIsPausedFlag(!State.getIsPausedFlag());
-  State.onPause(render);
+    State.setIsPausedFlag(!State.getIsPausedFlag());
+    State.onPause(render);
+  }
 };
 
 /*
@@ -226,5 +228,6 @@ Events.on(engine, 'beforeUpdate', function(event) {
     State.setIsPausedFlag(true);
     State.onPause(render);
     stopPlotInterval();
+    State.setSimulationRunning(false);
   }
 });

--- a/src/Pendulum/case5/sketch.js
+++ b/src/Pendulum/case5/sketch.js
@@ -154,19 +154,21 @@ function stopPlotInterval() {
 var pauseBtn = document.getElementById('pause-button');
 
 pauseBtn.onclick = function() {
-  if (pauseBtn.value == "pause") {
-    pauseBtn.innerText = "cont.";
-    pauseBtn.value = "continue";
-    stopPlotInterval();
-  }
-  else {
-    pauseBtn.value = "pause";
-    pauseBtn.innerText = "Pause";
-    runPlotInterval();
-  }
+  if (State.getSimulationRunning() === true) { // only allow pause and continue when the simulation is running
+    if (pauseBtn.value == "pause") {
+      pauseBtn.innerText = "cont.";
+      pauseBtn.value = "continue";
+      stopPlotInterval();
+    }
+    else {
+      pauseBtn.value = "pause";
+      pauseBtn.innerText = "Pause";
+      runPlotInterval();
+    }
 
-  State.setIsPausedFlag(!State.getIsPausedFlag());
-  State.onPause(render);
+    State.setIsPausedFlag(!State.getIsPausedFlag());
+    State.onPause(render);
+  }
 };
 
 /*
@@ -225,5 +227,6 @@ Events.on(engine, 'beforeUpdate', function(event) {
     State.setIsPausedFlag(true);
     State.onPause(render);
     stopPlotInterval();
+    State.setSimulationRunning(false);
   }
 });


### PR DESCRIPTION
Before this pull request the user was able to unpause the simulation after the simulation had paused itself, for example, in case 1 when the pendulum reaches its max height. This disables the pause button once this event happens. 