### PR TITLE
Fixes bug where user could click start after simulation ended

### DIFF
--- a/src/Pendulum/case1/sketch.js
+++ b/src/Pendulum/case1/sketch.js
@@ -154,7 +154,7 @@ pauseBtn.onclick = function() {
 */
 
 document.getElementById('start-button').onclick = function() {
-  if (State.getSimulationRunning() === false) { // make sure the simulation is not already running
+  if (engine.timing.timestamp === 0) { 
     State.setIsPausedFlag(false);
     State.onPause(render);
     State.setSimulationRunning(true);

--- a/src/Pendulum/case2/sketch.js
+++ b/src/Pendulum/case2/sketch.js
@@ -179,7 +179,7 @@ pauseBtn.onclick = function() {
 */
 
 document.getElementById('start-button').onclick = function() {
-  if (State.getSimulationRunning() === false) { // make sure the simulation is not already running
+  if (engine.timing.timestamp === 0) { 
     State.setIsPausedFlag(false);
     State.onPause(render);
     State.setSimulationRunning(true);

--- a/src/Pendulum/case3/sketch.js
+++ b/src/Pendulum/case3/sketch.js
@@ -179,7 +179,7 @@ pauseBtn.onclick = function() {
 */
 
 document.getElementById('start-button').onclick = function() {
-  if (State.getSimulationRunning() === false) { // make sure the simulation is not already running
+  if (engine.timing.timestamp === 0) { 
     State.setIsPausedFlag(false);
     State.onPause(render);
     State.setSimulationRunning(true);

--- a/src/Pendulum/case4/sketch.js
+++ b/src/Pendulum/case4/sketch.js
@@ -157,7 +157,7 @@ function stopPlotInterval() {
 var pauseBtn = document.getElementById('pause-button');
 
 pauseBtn.onclick = function() {
-  if (State.getSimulationRunning() === true) { // only allow pause and continue when the simulation is running
+  if (engine.timing.timestamp === 0) { 
     if (pauseBtn.value == "pause") {
       pauseBtn.innerText = "cont.";
       pauseBtn.value = "continue";

--- a/src/Pendulum/case5/sketch.js
+++ b/src/Pendulum/case5/sketch.js
@@ -179,7 +179,7 @@ pauseBtn.onclick = function() {
 */
 
 document.getElementById('start-button').onclick = function() {
-  if (State.getSimulationRunning() === false) { // make sure the simulation is not already running
+  if (engine.timing.timestamp === 0) { 
     State.setIsPausedFlag(false);
     State.onPause(render);
     State.setSimulationRunning(true);

--- a/src/Pendulum/exploratory/sketch.js
+++ b/src/Pendulum/exploratory/sketch.js
@@ -287,11 +287,11 @@ function calcYCoord(length, angle, yProc) {
 */
 
 function createWorld() {
-  World.add(engine.world, [  // x y w h 
-     Bodies.rectangle(400, 0, 800, 50, { isStatic: true, render: {fillStyle: 'grey'}}) ,   //top 
-     Bodies.rectangle(400, CANVAS_HEIGHT, 800, 50, { isStatic: true, render: {fillStyle: 'grey'}}) , // bottom 
+  World.add(engine.world, [  // x y w h
+     Bodies.rectangle(400, 0, 800, 50, { isStatic: true, render: {fillStyle: 'grey'}}) ,   //top
+     Bodies.rectangle(400, CANVAS_HEIGHT, 800, 50, { isStatic: true, render: {fillStyle: 'grey'}}) , // bottom
      Bodies.rectangle(800, 400, 50, 800, { isStatic: true, render: {fillStyle: 'grey'}}),
-     Bodies.rectangle(0, 400, 50, 800, { isStatic: true, render: {fillStyle: 'grey'}}) 
+     Bodies.rectangle(0, 400, 50, 800, { isStatic: true, render: {fillStyle: 'grey'}})
   ]);
   var xCoordProtractor = 400;
   var yCoordProtractor = 50;
@@ -427,7 +427,7 @@ pauseBtn.onclick = function() {
 */
 
 document.getElementById('start-button').onclick = function() {
-  if (State.getSimulationRunning() === false) { // make sure the simulation is not already running
+  if (engine.timing.timestamp === 0) { 
     State.setIsPausedFlag(false);
     State.onPause(render);
     State.setSimulationRunning(true);


### PR DESCRIPTION
Changes the check to be based on the engine's timestamp guaranteeing that the simulation can only start if the simulation has not started running.