### PR TITLE
Adds build-all script. Refactors build scripts to support older versions of node

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,44 +5,108 @@ let fs = require('fs');
 let browserify = require('browserify');
 let source = require('vinyl-source-stream');
 
+let folders = ['case1', 'case2', 'case3', 'case4', 'case5', 'exploratory'];
+
 /**
   * Minifies all js files in the build folder
 */
 
 gulp.task('minify', () => {
-  return gulp.src('./build/*.js').pipe(terser()).pipe(gulp.dest('./build'), {mode: 0777});
+  return new Promise((resolve, reject) => {
+    try {
+      for (let i = 0; i < folders.length; i++) {
+        fs.access(`./build/${folders[i]}`, (error) => {
+          if (error) {
+            console.log(`${folders[i]} folder does not exist. Skipping...`);
+          }
+          else {
+            gulp.src(`./build/${folders[i]}/*.js`).pipe(terser()).pipe(gulp.dest(`./build/${folders[i]}`), {mode: 0777});
+          }
+        });
+      }
+
+      resolve();
+    }
+    catch (error) {
+      console.log('Script could not be run: ' + error);
+      reject();
+    }
+  });
 });
 
+/**
+  * Builds all pendulum cases to the build folder
+*/
+
+gulp.task('build-all', () => {
+  return new Promise((resolve, reject) => {
+    try {
+      for (let i = 0; i < folders.length; i++) {
+        browserify(`./src/Pendulum/${folders[i]}/Sketch.js`).bundle().pipe(source('bundle.js')).pipe(gulp.dest(`./build/${folders[i]}`), {mode: 0777});
+        gulp.src(`./src/Pendulum/${folders[i]}/**/*.css`).pipe(gulp.dest(`./build/${folders[i]}`), {mode: 0777});
+        gulp.src(`./src/Pendulum/${folders[i]}/**/*.html`).pipe(gulp.dest(`./build/${folders[i]}`), {mode: 0777});
+      }
+
+      resolve();
+    }
+    catch (error) {
+      console.log('Script could not be run: ' + error);
+      reject();
+    }
+  });
+});
 
 /**
-  * Builds a pendulum case to the build folder
+  * Builds a single pendulum case to the build folder
   * Takes a command line argument --case [case] where case is a folder name
 */
 
-gulp.task('build', async () => {
-  if (process.argv.indexOf('--case') !== -1) {
-    let folder = process.argv[process.argv.indexOf('--case') + 1];
+gulp.task('build', () => {
+  return new Promise((resolve, reject) => {
+    try {
+      if (process.argv.indexOf('--case') !== -1) {
+        let folder = process.argv[process.argv.indexOf('--case') + 1];
 
-    browserify(`./src/Pendulum/${folder}/Sketch.js`).bundle().pipe(source('bundle.js')).pipe(gulp.dest('./build'), {mode: 0777});
-    gulp.src(`./src/Pendulum/${folder}/**/*.css`).pipe(gulp.dest('./build'), {mode: 0777});
-    gulp.src(`./src/Pendulum/${folder}/**/*.html`).pipe(gulp.dest('./build'), {mode: 0777});
-  }
-  else {
-    console.log('Error: The folder to build was not specified. Enter the command gulp build --case [Your Case].');
-  }
+        browserify(`./src/Pendulum/${folder}/Sketch.js`).bundle().pipe(source('bundle.js')).pipe(gulp.dest('./build'), {mode: 0777});
+        gulp.src(`./src/Pendulum/${folder}/**/*.css`).pipe(gulp.dest('./build'), {mode: 0777});
+        gulp.src(`./src/Pendulum/${folder}/**/*.html`).pipe(gulp.dest('./build'), {mode: 0777});
+      }
+      else {
+        console.log('Error: The folder to build was not specified. Enter the command gulp build --case [Your Case].');
+      }
+
+      resolve();
+    }
+    catch (error) {
+      console.log('Script could not be run: ' + error);
+      reject();
+    }
+  });
 });
 
 /**
   * Cleans the build directory
 */
 
-gulp.task('clean', async () => {
-  fs.access('./build', (error) => {
-    if (error) {
-      console.log('Error: ./build does not exist.');
+gulp.task('clean', () => {
+  return new Promise((resolve, reject) => {
+    try {
+      fs.access('./build', (error) => {
+        if (error) {
+          console.log('Error: ./build does not exist.');
+        }
+        else {
+          gulp.src('./build', {read: false}).pipe(clean(), {mode: 0777});
+        }
+      });
+
+      resolve();
     }
-    else {
-      gulp.src('./build', {read: false}).pipe(clean(), {mode: 0777});
+    catch (error) {
+      console.log('Script could not be run: ' + error);
+      reject();
     }
   });
 });
+
+gulp.task('default', gulp.series('build-all'));


### PR DESCRIPTION
Adds build-all script to compile all folders
Adds default command 'gulp' to route to build-all
Refactors scripts to be compatible with older versions of node by using promises instead of async/await